### PR TITLE
fix autograder failure check

### DIFF
--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -86,6 +86,6 @@
 
           # fail job if autograder returns failed
           - name: check autograder pass fail
-            if: ${{ steps.autograder.outcome }}
+            if: ${{ steps.autograder.outcome == 'failure' }}
             # if: ${{ failure }}
             run: exit 1

--- a/.github/workflows/classroom.yml
+++ b/.github/workflows/classroom.yml
@@ -85,7 +85,10 @@
               branch: badges
 
           # fail job if autograder returns failed
+          # outcome can be 'success', 'failure', 'cancelled', or 'skipped'
+          # trigger fail either on !success or on failure depending on preference
           - name: check autograder pass fail
-            if: ${{ steps.autograder.outcome == 'failure' }}
+            if: ${{ steps.autograder.outcome != 'success' }}
+            # if: ${{ steps.autograder.outcome == 'failure' }}
             # if: ${{ failure }}
             run: exit 1


### PR DESCRIPTION
- close #1
- explicitly check the return value (either 'success' or 'failure')